### PR TITLE
Bug fixes and model version check utils

### DIFF
--- a/requirements.llamacpp.txt
+++ b/requirements.llamacpp.txt
@@ -2,7 +2,7 @@
 --extra-index-url https://download.pytorch.org/whl/cu121
 # --extra-index-url https://download.pytorch.org/whl/cu118
 torch>=2.1.0
-transformers==4.33.2
+transformers==4.38.0
 scipy
 numpy
 

--- a/requirements.ollama.txt
+++ b/requirements.ollama.txt
@@ -2,7 +2,7 @@
 --extra-index-url https://download.pytorch.org/whl/cu121
 # --extra-index-url https://download.pytorch.org/whl/cu118
 torch>=2.1.0
-transformers==4.33.2
+transformers==4.38.0
 scipy
 numpy
 ollama

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 --extra-index-url https://download.pytorch.org/whl/cu121
 # --extra-index-url https://download.pytorch.org/whl/cu118
 torch>=2.1.0
-transformers==4.33.2
+transformers==4.38.0
 auto-gptq
 sentencepiece
 bitsandbytes

--- a/tests/single.py
+++ b/tests/single.py
@@ -8,9 +8,9 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 parser = argparse.ArgumentParser()
-parser.add_argument('url', type=str, default='http://127.0.0.1:5000')
-parser.add_argument('--auth', type=str, default='sakura:itsmygo')
-parser.add_argument('--prefix', type=int, default=None)
+parser.add_argument('url', type=str, nargs='*', default='http://127.0.0.1:5000')
+parser.add_argument('--auth', type=str, nargs='*', default='sakura:itsmygo')
+parser.add_argument('--prefix', type=int, nargs='*', default=None)
 
 args = parser.parse_args()
 logger.info(args)

--- a/tests/stream.py
+++ b/tests/stream.py
@@ -8,9 +8,9 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 parser = argparse.ArgumentParser()
-parser.add_argument('url', type=str, default='http://127.0.0.1:5000')
-parser.add_argument('--auth', type=str, default='sakura:itsmygo')
-parser.add_argument('--prefix', type=int, default=None)
+parser.add_argument('url', type=str, nargs='*', default='http://127.0.0.1:5000')
+parser.add_argument('--auth', type=str, nargs='*', default='sakura:itsmygo')
+parser.add_argument('--prefix', type=int, nargs='*', default=None)
 
 args = parser.parse_args()
 logger.info(args)

--- a/tests/test_version_checker.py
+++ b/tests/test_version_checker.py
@@ -1,0 +1,30 @@
+import unittest
+
+from utils import is_version_compatible
+
+
+class TestVersionCompatibility(unittest.TestCase):
+
+    def test_compatible_versions(self):
+        compatible_versions = ["1.2.3", "1.3.0", "2.0.0"]
+
+        # Test cases to assert compatibility
+        self.assertTrue(is_version_compatible("1.2", compatible_versions))
+        self.assertTrue(is_version_compatible("1.3", compatible_versions))
+
+        # Test cases to assert incompatibility
+        self.assertFalse(is_version_compatible("2.1", compatible_versions))
+
+        # Matching exact version
+        self.assertTrue(is_version_compatible("2.1", ["2.1"]))
+
+    def test_pre_release_versions(self):
+        self.assertTrue(is_version_compatible("0.10", ["0.10", "0.10pre", "0.10.1"]))
+
+        # Compatible pre-release version
+        self.assertTrue(is_version_compatible("0.10", ["0.10pre"]))
+        self.assertTrue(is_version_compatible("0.10pre", ["0.10"]))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/translate_epub.py
+++ b/translate_epub.py
@@ -210,7 +210,7 @@ def main():
         if args.translate_title:
             temp_gpt_dict = get_gpt_dict(f[:-5])
             prompt = consts.get_prompt(
-                input=f[:-5],
+                raw_jp_text=f[:-5],
                 model_name=sakura_model.cfg.model_name,
                 model_version=sakura_model.cfg.model_version,
                 model_quant=sakura_model.cfg.model_quant,
@@ -235,7 +235,7 @@ def main():
                 if args.translate_title:
                     temp_gpt_dict = get_gpt_dict(f[:-5])
                     prompt = consts.get_prompt(
-                        input=f[:-5],
+                        raw_jp_text=f[:-5],
                         model_name=sakura_model.cfg.model_name,
                         model_version=sakura_model.cfg.model_version,
                         model_quant=sakura_model.cfg.model_quant,
@@ -275,7 +275,7 @@ def main():
                     temp_gpt_dict = get_gpt_dict(text)
                     print(f"{len(temp_gpt_dict)=}")
                     prompt = consts.get_prompt(
-                        input=text,
+                        raw_jp_text=text,
                         model_name=sakura_model.cfg.model_name,
                         model_version=sakura_model.cfg.model_version,
                         model_quant=sakura_model.cfg.model_quant,

--- a/translate_novel.py
+++ b/translate_novel.py
@@ -218,7 +218,7 @@ def main():
         data = ""
         for d in tqdm(data_list):
             prompt = consts.get_prompt(
-                input=d,
+                raw_jp_text=d,
                 model_name=sakura_model.cfg.model_name,
                 model_version=sakura_model.cfg.model_version,
                 model_quant=sakura_model.cfg.model_quant,

--- a/translate_sub.py
+++ b/translate_sub.py
@@ -239,7 +239,7 @@ def main():
     data = ""
     for d in tqdm(data_list):
         prompt = consts.get_prompt(
-            input=d,
+            raw_jp_text=d,
             model_name=sakura_model.cfg.model_name,
             model_version=sakura_model.cfg.model_version,
             model_quant=sakura_model.cfg.model_quant,

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -2,21 +2,23 @@ import logging
 from pprint import pprint, pformat
 from transformers import GenerationConfig
 
+from utils.version_checker import is_version_compatible
+
 logger = logging.getLogger(__name__)
 
 
 def split_response(response, model_version):
     response = response.replace("</s>", "")
-    if model_version == '0.5' or '0.8' in model_version:
+    if is_version_compatible(model_version, ["0.5", "0.8"]):
         output = response.split("<reserved_107>")[1]
         return output
-    if '0.7' in model_version or '0.9' in model_version or '0.10' in model_version:
+    if is_version_compatible(model_version, ["0.7", "0.9", "0.10"]):
         output = response.split("<|im_start|>assistant\n")[1]
         return output
-    if model_version == '0.1':
+    if is_version_compatible(model_version, ["0.1"]):
         output = response.split("\n\nAssistant: \n")[1]
         return output
-    if model_version == '0.4':
+    if is_version_compatible(model_version, ["0.4"]):
         output = response.split("\nAssistant: ")[1]
         return output
 
@@ -25,7 +27,7 @@ def split_response(response, model_version):
 
 def detect_degeneration(generation: list, model_version):
     #TODO: refactor this
-    if model_version != "0.8":
+    if not is_version_compatible(model_version, ["0.8"]):
         return False
     i = generation.index(196)
     generation = generation[i+1:]

--- a/utils/consts.py
+++ b/utils/consts.py
@@ -15,17 +15,17 @@ class ModelTestCase:
     test_output: str
 
 
-def get_prompt(input, model_name:str, model_version:str, model_quant:str=None, gpt_dict:list=[]):
+def get_prompt(raw_jp_text, model_name:str, model_version:str, model_quant:str=None, gpt_dict:list=[]):
     # FIXME(kuriko): hardcoded here for llama_cpp quant model
     if model_name == 'llama_cpp':
-        prompt = "<reserved_106>将下面的日文文本翻译成中文：" + input + "<reserved_107>"
+        prompt = "<reserved_106>将下面的日文文本翻译成中文：" + raw_jp_text + "<reserved_107>"
         return prompt
 
     if model_version == '0.5' or "0.8" in model_version:
-        prompt = "<reserved_106>将下面的日文文本翻译成中文：" + input + "<reserved_107>"
+        prompt = "<reserved_106>将下面的日文文本翻译成中文：" + raw_jp_text + "<reserved_107>"
         return prompt
     if "0.9" in model_version:
-        prompt = f"<|im_start|>system\n你是一个轻小说翻译模型，可以流畅通顺地以日本轻小说的风格将日文翻译成简体中文，并联系上下文正确使用人称代词，不擅自添加原文中没有的代词。<|im_end|>\n<|im_start|>user\n将下面的日文文本翻译成中文：{input}<|im_end|>\n<|im_start|>assistant\n"
+        prompt = f"<|im_start|>system\n你是一个轻小说翻译模型，可以流畅通顺地以日本轻小说的风格将日文翻译成简体中文，并联系上下文正确使用人称代词，不擅自添加原文中没有的代词。<|im_end|>\n<|im_start|>user\n将下面的日文文本翻译成中文：{raw_jp_text}<|im_end|>\n<|im_start|>assistant\n"
         return prompt
     if "0.10" in model_version:
         gpt_dict_text_list = []
@@ -41,19 +41,19 @@ def get_prompt(input, model_name:str, model_version:str, model_quant:str=None, g
 
         gpt_dict_raw_text = "\n".join(gpt_dict_text_list)
 
-        user_prompt = "根据以下术语表（可以为空）：\n" + gpt_dict_raw_text + "\n\n" + "将下面的日文文本根据上述术语表的对应关系和备注翻译成中文：" + input
+        user_prompt = "根据以下术语表（可以为空）：\n" + gpt_dict_raw_text + "\n\n" + "将下面的日文文本根据上述术语表的对应关系和备注翻译成中文：" + raw_jp_text
         prompt = "<|im_start|>system\n你是一个轻小说翻译模型，可以流畅通顺地使用给定的术语表以日本轻小说的风格将日文翻译成简体中文，并联系上下文正确使用人称代词，注意不要混淆使役态和被动态的主语和宾语，不要擅自添加原文中没有的代词，也不要擅自增加或减少换行。<|im_end|>\n" \
         + "<|im_start|>user\n" + user_prompt + "<|im_end|>\n" \
         + "<|im_start|>assistant\n" # assistant prompt start
         return prompt
     if model_version == '0.7':
-        prompt = f"<|im_start|>user\n将下面的日文文本翻译成中文：{input}<|im_end|>\n<|im_start|>assistant\n"
+        prompt = f"<|im_start|>user\n将下面的日文文本翻译成中文：{raw_jp_text}<|im_end|>\n<|im_start|>assistant\n"
         return prompt
     if model_version == '0.1':
-        prompt = "Human: \n将下面的日文文本翻译成中文：" + input + "\n\nAssistant: \n"
+        prompt = "Human: \n将下面的日文文本翻译成中文：" + raw_jp_text + "\n\nAssistant: \n"
         return prompt
     if model_version == '0.4':
-        prompt = "User: 将下面的日文文本翻译成中文：" + input + "\nAssistant: "
+        prompt = "User: 将下面的日文文本翻译成中文：" + raw_jp_text + "\nAssistant: "
         return prompt
 
     raise ValueError(f"Wrong model version{model_version}, please view https://huggingface.co/sakuraumi/Sakura-13B-Galgame")

--- a/utils/consts.py
+++ b/utils/consts.py
@@ -1,8 +1,10 @@
 from dataclasses import dataclass
+
 from pydantic import BaseModel
 from transformers import GenerationConfig
-from types import *
 import logging
+
+from utils.version_checker import is_version_compatible
 
 logger = logging.getLogger(__name__)
 
@@ -15,19 +17,19 @@ class ModelTestCase:
     test_output: str
 
 
-def get_prompt(raw_jp_text, model_name:str, model_version:str, model_quant:str=None, gpt_dict:list=[]):
+def get_prompt(raw_jp_text, model_name: str, model_version: str, model_quant: str = None, gpt_dict: list = []):
     # FIXME(kuriko): hardcoded here for llama_cpp quant model
     if model_name == 'llama_cpp':
         prompt = "<reserved_106>将下面的日文文本翻译成中文：" + raw_jp_text + "<reserved_107>"
         return prompt
 
-    if model_version == '0.5' or "0.8" in model_version:
+    if is_version_compatible(model_version, ["0.5", "0.8"]):
         prompt = "<reserved_106>将下面的日文文本翻译成中文：" + raw_jp_text + "<reserved_107>"
         return prompt
-    if "0.9" in model_version:
+    if is_version_compatible(model_version, ["0.9"]):
         prompt = f"<|im_start|>system\n你是一个轻小说翻译模型，可以流畅通顺地以日本轻小说的风格将日文翻译成简体中文，并联系上下文正确使用人称代词，不擅自添加原文中没有的代词。<|im_end|>\n<|im_start|>user\n将下面的日文文本翻译成中文：{raw_jp_text}<|im_end|>\n<|im_start|>assistant\n"
         return prompt
-    if "0.10" in model_version:
+    if is_version_compatible(model_version, ["0.10"]):
         gpt_dict_text_list = []
         for gpt in gpt_dict:
             src = gpt['src']
@@ -43,23 +45,24 @@ def get_prompt(raw_jp_text, model_name:str, model_version:str, model_quant:str=N
 
         user_prompt = "根据以下术语表（可以为空）：\n" + gpt_dict_raw_text + "\n\n" + "将下面的日文文本根据上述术语表的对应关系和备注翻译成中文：" + raw_jp_text
         prompt = "<|im_start|>system\n你是一个轻小说翻译模型，可以流畅通顺地使用给定的术语表以日本轻小说的风格将日文翻译成简体中文，并联系上下文正确使用人称代词，注意不要混淆使役态和被动态的主语和宾语，不要擅自添加原文中没有的代词，也不要擅自增加或减少换行。<|im_end|>\n" \
-        + "<|im_start|>user\n" + user_prompt + "<|im_end|>\n" \
-        + "<|im_start|>assistant\n" # assistant prompt start
+                 + "<|im_start|>user\n" + user_prompt + "<|im_end|>\n" \
+                 + "<|im_start|>assistant\n"  # assistant prompt start
         return prompt
-    if model_version == '0.7':
+    if is_version_compatible(model_version, ["0.7"]):
         prompt = f"<|im_start|>user\n将下面的日文文本翻译成中文：{raw_jp_text}<|im_end|>\n<|im_start|>assistant\n"
         return prompt
-    if model_version == '0.1':
+    if is_version_compatible(model_version, ["0.1"]):
         prompt = "Human: \n将下面的日文文本翻译成中文：" + raw_jp_text + "\n\nAssistant: \n"
         return prompt
-    if model_version == '0.4':
+    if is_version_compatible(model_version, ["0.4"]):
         prompt = "User: 将下面的日文文本翻译成中文：" + raw_jp_text + "\nAssistant: "
         return prompt
 
-    raise ValueError(f"Wrong model version{model_version}, please view https://huggingface.co/sakuraumi/Sakura-13B-Galgame")
+    raise ValueError(
+        f"Wrong model version{model_version}, please view https://huggingface.co/sakuraumi/Sakura-13B-Galgame")
 
 
-def get_test_case_by_model_version(model_name:str, model_version:str, model_quant:str):
+def get_test_case_by_model_version(model_name: str, model_version: str, model_quant: str):
     default_generation_config = GenerationConfig(
         num_beams=1,
         max_new_tokens=20,
@@ -67,7 +70,7 @@ def get_test_case_by_model_version(model_name:str, model_version:str, model_quan
         do_sample=False,
     )
 
-    if model_name == "llama_cpp" or model_version in "0.8 0.9 0.10":
+    if model_name == "llama_cpp" or is_version_compatible(model_version, ["0.8", "0.9", "0.10"]):
         return ModelTestCase(
             model_version=model_version,
             generation_config=default_generation_config,

--- a/utils/model.py
+++ b/utils/model.py
@@ -11,7 +11,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer, GenerationConfig, 
 
 import utils
 from sampler_hijack import hijack_samplers
-from utils import consts, log_generation_config
+from utils import consts, log_generation_config, is_version_compatible
 
 if TYPE_CHECKING:
     from transformers import LlamaForCausalLM, LlamaTokenizer
@@ -66,9 +66,8 @@ def load_model(args: SakuraModelConfig) -> (Any, ModelTypes):
 
     if not args.llama_cpp and (args.use_gpu or args.n_gpu_layers != 0):
         logger.warning("You are using both use_gpu and n_gpu_layers flag without --llama_cpp.")
-        if args.trust_remote_code is False and args.model_version in "0.5 0.7 0.8 0.9 0.10":
+        if args.trust_remote_code is False and is_version_compatible(args.model_version, ["0.5", "0.7", "0.8", "0.9", "0.10"]):
             args.trust_remote_code = True
-            # raise ValueError("If you use model version 0.5, 0.7, 0.8 or 0.9, please add flag --trust_remote_code.")
 
     logger.info("loading model ...")
 

--- a/utils/version_checker.py
+++ b/utils/version_checker.py
@@ -1,0 +1,11 @@
+from typing import List
+from packaging.version import Version
+
+
+def is_version_compatible(target_version: str, versions: List[str]) -> bool:
+    target = Version(target_version)
+
+    return any(
+        (target.major == v.major and target.minor == v.minor)
+        for v in map(Version, versions)
+    )


### PR DESCRIPTION
### Upgraded transformers from 4.33.2 to 4.38.0
Transformers 4.33.2 is vulnerable to https://github.com/advisories/GHSA-3863-2447-669p, https://github.com/advisories/GHSA-v68g-wm8c-6x7j, https://github.com/advisories/GHSA-37q5-v5qm-c9v8.

### Fixed bug: single.py and stream.py default argument not working
Added `nargs='*'` to fix the argparse `default` parameter.

### Renamed get_prompt parameter
Renamed `input` parameter to raw_jp_text, as `input` shadows python built-in method name.

### Added a new version check tool
Added `is_version_compatible` to compare version strings. This will also fix bugs like version `0.9.2` not recognized as subversion of `0.9`. A new unit test is also added.
